### PR TITLE
Locked Lazarus to 2.0.12

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  CORE_VERSION: "4.6"
+  CORE_VERSION: "1.0"
 
 jobs:
   setup:
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate Maven settings.xml
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v22
         with:
           output_file: "/etc/maven/settings.xml"
           servers:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  CORE_VERSION: "4.6"
+  CORE_VERSION: "1.0"
 
 jobs:
   setup:
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate Maven settings.xml
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v22
         with:
           output_file: "/etc/maven/settings.xml"
           servers:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>dk.epidata.core</groupId>
     <artifactId>epidata-core</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <profiles>
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>dk.epidata.lazarus</groupId>
             <artifactId>lazarus</artifactId>
-            <version>[2.0.10,2.0.11)</version>
+            <version>2.0.10</version>
             <type>pom</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
* In order to not mess up builds with similar code bases, but on different FPC versions we should lock ranges.
* Reset maven version range to differentiate between code base and pipeline builds