### PR TITLE
Allow for case insitive integrity check

### DIFF
--- a/epidatacore.lpk
+++ b/epidatacore.lpk
@@ -17,10 +17,12 @@
       </Parsing>
       <CodeGeneration>
         <SmartLinkUnit Value="True"/>
+        <Optimizations>
+          <OptimizationLevel Value="0"/>
+        </Optimizations>
       </CodeGeneration>
       <Linking>
         <Debugging>
-          <GenerateDebugInfo Value="False"/>
           <DebugInfoType Value="dsDwarf2Set"/>
         </Debugging>
       </Linking>

--- a/epidatacore_visuals.lpk
+++ b/epidatacore_visuals.lpk
@@ -17,12 +17,11 @@
       <CodeGeneration>
         <SmartLinkUnit Value="True"/>
         <Optimizations>
-          <OptimizationLevel Value="2"/>
+          <OptimizationLevel Value="0"/>
         </Optimizations>
       </CodeGeneration>
       <Linking>
         <Debugging>
-          <GenerateDebugInfo Value="False"/>
           <DebugInfoType Value="dsDwarf2Set"/>
         </Debugging>
       </Linking>


### PR DESCRIPTION
In preparation for case insensitive merge the integrity tool also needs to accept case insensitive check.